### PR TITLE
W2_S2 imshow origin error

### DIFF
--- a/IP/W2_S2_Tutorial.ipynb
+++ b/IP/W2_S2_Tutorial.ipynb
@@ -730,7 +730,7 @@
       "source": [
         "fig, ax = plt.subplots(figsize=(12,4), ncols=2)\n",
         "ax[0].imshow(f)\n",
-        "ax[1].imshow(f, origin='bottom')"
+        "ax[1].imshow(f, origin='lower')"
       ],
       "metadata": {
         "id": "bMcztn89Ct_t"


### PR DESCRIPTION
Change imshow origin value from `bottom` to `lower` in **2D Plotting Methods** section in the W2_S2_Tutorial nb.
[matplotlib.pyplot.imshow docs](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html#matplotlib.pyplot.imshow)